### PR TITLE
Make table responsive

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,58 +21,59 @@ layout: base
           <input type="search" class="search" placeholder="Filter..." disabled />
         </form>
 
-        <table>
-          <tr>
-            <th scope="col">
-              <button class="outline sort" data-sort="model" title="Sort by open access model" disabled></button>
-            </th>
-            <th scope="col">
-              <strong>Journal</strong>
-              <button class="outline sort" data-sort="title" title="Sort by title" disabled></button>
-            </th>
-            <th scope="col">
-              <strong>Publisher</strong>
-              <button class="outline sort" data-sort="publisher" title="Sort by publisher" disabled></button>
-            </th>
-            <th scope="col"><strong>Languages</strong></th>
-            <th scope="col"><strong>ISSN</strong></th>
-          </tr>
+        <div class=table-container>
+          <table>
+            <tr>
+              <th scope="col">
+                <button class="outline sort" data-sort="model" title="Sort by open access model" disabled></button>
+              </th>
+              <th scope="col" class="journal-col">
+                <strong>Journal</strong>
+                <button class="outline sort" data-sort="title" title="Sort by title" disabled></button>
+              </th>
+              <th scope="col">
+                <strong>Publisher</strong>
+                <button class="outline sort" data-sort="publisher" title="Sort by publisher" disabled></button>
+              </th>
+              <th scope="col"><strong>Languages</strong></th>
+              <th scope="col"><strong>ISSN</strong></th>
+            </tr>
 
-          <tbody class="list">
-            {%- for journal in journals %}
+            <tbody class="list">
+              {%- for journal in journals %}
 
-              <tr>
-                <td class="model center">
-                  {% include model.html model=journal.model %}
-                </td>
-                <td class="title" data-title="{{ journal.title }}">
-                  <cite>
-                    <a href="{{ journal.website }}" title="{{ journal.title }} home page">
-                      {{ journal.title }}
-                    </a>
-                  </cite>
-                </td>
-                <td class="publisher">{{ journal.publisher }}</td>
-                <td>
-                  {% assign languages = journal.languages %}
-                  {%- if languages.size > 1 -%}
-                  <ul style="list-style-type: none; margin: 0;">
-                      {%- for lang in languages %}
-                        <li>{% include language.html lang=lang %}</li>
-                      {%- endfor %}
-                    </ul>
-                  {%- else -%}
-                    {% include language.html lang=languages.first %}
-                  {%- endif -%}
-                </td>
-                <td>{% include issn.html issn=journal.issn %}</td>
-              </tr>
+                <tr>
+                  <td class="model center">
+                    {% include model.html model=journal.model %}
+                  </td>
+                  <td class="title" data-title="{{ journal.title }}">
+                    <cite>
+                      <a href="{{ journal.website }}" title="{{ journal.title }} home page">
+                        {{ journal.title }}
+                      </a>
+                    </cite>
+                  </td>
+                  <td class="publisher">{{ journal.publisher }}</td>
+                  <td>
+                    {% assign languages = journal.languages %}
+                    {%- if languages.size > 1 -%}
+                    <ul style="list-style-type: none; margin: 0;">
+                        {%- for lang in languages %}
+                          <li>{% include language.html lang=lang %}</li>
+                        {%- endfor %}
+                      </ul>
+                    {%- else -%}
+                      {% include language.html lang=languages.first %}
+                    {%- endif -%}
+                  </td>
+                  <td>{% include issn.html issn=journal.issn %}</td>
+                </tr>
 
-            {%- endfor %}
-          </tbody>
+              {%- endfor %}
+            </tbody>
 
-        </table>
-
+          </table>
+        </div>
       </article>
 
     </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -23,3 +23,18 @@ button.sort:focus {
 .sort.asc:after {
   content: "\2193";
 }
+
+
+@media screen and (max-width: 720px) {
+  .table-container {
+    overflow-x:auto;
+  }
+
+
+  table .title,
+  table .journal-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+  }
+}


### PR DESCRIPTION
Tweaks the home html layout and the css so that the table is a bit more responsive on mobile. 
Also makes so that the "Journal" column sticks on the left when swiping. This is kind of opinionated, it can be changed. All these changes only appear on mobile.

It's a very quick and dirty solution (using classes instead of semantics), if we stick with the table we might want to find a better way to do it probably.