### PR TITLE
Add navbar

### DIFF
--- a/_data/nav-main.yml
+++ b/_data/nav-main.yml
@@ -1,0 +1,8 @@
+left:
+  - name: Home
+    link: /
+right:
+  - name: About
+    link: /about/
+  - name: OA Reference Guide
+    link: https://pad.riseup.net/p/BViBIy0MxHMFgA4OMS9p-keep

--- a/_data/nav-main.yml
+++ b/_data/nav-main.yml
@@ -2,7 +2,5 @@ left:
   - name: Home
     link: /
 right:
-  - name: About
-    link: /about/
-  - name: OA Reference Guide
-    link: https://pad.riseup.net/p/BViBIy0MxHMFgA4OMS9p-keep
+  - name: OA Models
+    link: /oa-models

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,22 @@
+<header class="container">
+    <nav>            
+        <ul>
+            {% for item in site.data.nav-main.left -%}
+            <li>
+                <a href="{{ item.link }}">{{ item.name  }}</a>
+            </li>
+            {%- endfor %}
+        </ul>
+        <ul>
+            {% for item in site.data.nav-main.right -%}
+            <li>
+                <a href="{{ item.link }}">{{ item.name  }}</a>
+            </li>
+            {%- endfor %}
+        </ul>
+    </nav>
+      <hgroup>
+        <h1>{{ site.title | escape }}</h1>
+        <p>{{ site.description | escape }}</p>
+      </hgroup>
+</header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,16 +1,16 @@
 <header class="container">
-    <nav>            
+    <nav aria-label="Main navigation">            
         <ul>
             {% for item in site.data.nav-main.left -%}
             <li>
-                <a href="{{ item.link }}">{{ item.name  }}</a>
+                <a {% if page.url contains item.link %} aria-current="page"{% endif %} href="{{ item.link }}">{{ item.name  }}</a>
             </li>
             {%- endfor %}
         </ul>
         <ul>
             {% for item in site.data.nav-main.right -%}
             <li>
-                <a href="{{ item.link }}">{{ item.name  }}</a>
+                <a {% if page.url contains item.link %} aria-current="page"{% endif %} href="{{ item.link }}">{{ item.name  }}</a>
             </li>
             {%- endfor %}
         </ul>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,13 +20,8 @@
 
   <body>
 
-    <header class="container">
-      <hgroup>
-        <h1>{{ site.title | escape }}</h1>
-        <p>{{ site.description | escape }}</p>
-      </hgroup>
-    </header>
-
+    {% include header.html %}
+    
     <main class="container">
       {{ content }}
     </main>

--- a/css/styles.css
+++ b/css/styles.css
@@ -8,6 +8,10 @@ nav ol {
   column-gap: 0.5rem;
 }
 
+nav a[aria-current="page"] {
+  font-weight: 600;
+}
+
 /* Others */
 .center {
   text-align: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,14 @@
+/* Nav */
+nav {
+  margin-bottom: 1rem;
+}
+
+nav ul,
+nav ol {
+  column-gap: 0.5rem;
+}
+
+/* Others */
 .center {
   text-align: center;
 }

--- a/oa-models.md
+++ b/oa-models.md
@@ -1,11 +1,10 @@
 ---
 layout: page
-title: OA Models Reference Guide
+title: OA Models
 permalink: /oa-models/
 ---
 
-## OA Models Reference Guide
-
+## OA Models
 Open Access (OA) is a set of principles and practices that encourage unrestricted distribution of published scientific work.
 Various models have emerged for achieving this aim, which are sustained in different ways and with different stakeholders' needs in mind.
 
@@ -39,7 +38,7 @@ Works published in this manner are sometimes presented using some proprietary re
 
 ### Other relevant concepts and initiatives:
 
-🗄️ **[FAIR](https://www.go-fair.org/)** is an acronym for Findable, Accessible, Interoperable and Reusable, and is typically applied in contexts of data-sharing, which is another important pillar of the broader Open Science movement.
+🗄️ **[FAIR](https://www.go-fair.org/fair-principles/)** is an acronym for Findable, Accessible, Interoperable and Reusable, and is typically applied in contexts of data-sharing, which is another important pillar of the broader Open Science movement.
 
 🗃️ **Open Metadata** comprises a series of initiatives to ensure greater access to scholarly publishing metadata.
 For instance, [Open Citations](https://i4oc.org/) and [Open Abstracts](https://i4oa.org/) promote sharing of structured metadata elements in machine-readable formats.

--- a/oa-models.md
+++ b/oa-models.md
@@ -1,0 +1,50 @@
+---
+layout: page
+title: OA Models Reference Guide
+permalink: /oa-models/
+---
+
+## OA Models Reference Guide
+
+Open Access (OA) is a set of principles and practices that encourage unrestricted distribution of published scientific work.
+Various models have emerged for achieving this aim, which are sustained in different ways and with different stakeholders' needs in mind.
+
+💎 **Diamond OA** refers to journals that publish open access without charging authors article processing charges (APC).
+These venues are usually community-run, and are typically funded through academic institutions, philanthropists or government grants.
+Diamond OA is sometimes also referred to as "Platinum" OA.
+
+🌿 **Green OA** refers to self-archiving of research outputs in publicly-accessible institutional or subject repositories.
+Articles posted to a Green OA repository may, but must not necessarily, derive from traditional publishing protocols.
+This model therefore affords great flexibility.
+However, journals sometimes impose restrictions on posting articles in Green OA repositories, depending on the terms of the publishing agreement.
+For instance, some journals specify an embargo period (typically between 1-3 years), during which time authors are prohibited from freely sharing their work.
+Authors may also only be allowed to share versions of a paper that have not been fully typeset according to the publisher's style.
+You can check the terms of your own publishing agreements using the [Sherpa Romeo](https://www.sherpa.ac.uk/romeo/) tool.
+
+👑 **Gold OA** refers to journals that publish open access in exchange for article processing charges (APC) paid by the author.
+This is meant to defray the costs that would otherwise be covered through readers' journal subscriptions.
+This model offloads publishers' financial burdens onto authors, which disproportionately affects scholars working in the global south, early career researchers, and scientists working at institutions that provide limited financial support for research purposes.
+Some universities and philanthropic funding agencies have reached [transformative agreements](https://www.coalition-s.org/faq/what-is-a-transformative-agreement/), which cover the APCs for all work that they support.
+In some cases, authors may apply for a substantial discount or have the APC waived entirely if they can demonstrate their inability to access requisite funding.
+
+🫰🏻 **Hybrid** journals give authors the option to pay an APC to make their work OA (essentially the same as Gold OA), or to keep their article behind a paywall without paying any APC.
+The publisher therefore charges both authors and readers for the same service.
+Hybrid journals never discount or waive APCs for authors who can not afford them due to the availability of non-open / subscriber-funded options.
+
+🥔 **Bronze OA** refers to articles that are free to read on the publisher's webpage, but without clear details on how they can be transformed or reused.
+Works published in this manner are sometimes presented using some proprietary rendering engine or restrictive file formats.
+
+🏴‍☠️ **Black OA** refers to unauthorized access to paywalled literature using pirate sites such as [Sci-Hub](https://www.sci-hub.wf/) or [LibGen](https://libgen.is/). [Anna's Archive](https://annas-archive.org/) currently serves as a portal that consolidates access to various pirate archives.
+
+
+### Other relevant concepts and initiatives:
+
+🗄️ **[FAIR](https://www.go-fair.org/)** is an acronym for Findable, Accessible, Interoperable and Reusable, and is typically applied in contexts of data-sharing, which is another important pillar of the broader Open Science movement.
+
+🗃️ **Open Metadata** comprises a series of initiatives to ensure greater access to scholarly publishing metadata.
+For instance, [Open Citations](https://i4oc.org/) and [Open Abstracts](https://i4oa.org/) promote sharing of structured metadata elements in machine-readable formats.
+
+🖍️ **Open Peer-Review** is an initiative to make peer-review a publicly-visible process.
+Reviewers, who are usually, but not necessarily, invited to participate by the journal's editors, share their comments in response to authors' pre-review pre-prints posted on the journal's Green OA repository.
+Authors' responses to reviews' feedback and modifications to the paper are also publicly visible.
+[Peer Community In (PCI) Archaeology](https://archaeo.peercommunityin.org/) is one platform providing this service to archaeologists.


### PR DESCRIPTION
Adds a navbar to the top using Pico defaults. Some css tweaks for better spacing (especially on mobile). Navbar items are generated from `_data/nav-main.yml` file (with separate sections for left- and right-aligned items). Adds also aria elements for accessibility. The bold color in the `Home` element, instead of being hardcoded as in Pico's example is dependent on the current page.

The about page is non-existent for now, not sure if we want to have one or not.

In the future we might also think about linking multiple resources in a dropdown menu named e.g. "Resources" or keep them as single navbar elements.